### PR TITLE
Update node-jq post install script execution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Install jq for tests
-        run: npm explore node-jq && npm run install-binary
+        run: node -r node-jq/scripts/install-binary.js
 
       - name: Build
         run: yarn prepack


### PR DESCRIPTION
`npm explore` uses shell trickery to provide its functionality, and is not compatible with pipeline use. Move to using `node -r` for execution.