### PR TITLE
feat: RulesEngine Optimization

### DIFF
--- a/src/plugins/policyPack/index.ts
+++ b/src/plugins/policyPack/index.ts
@@ -321,7 +321,7 @@ export default class PolicyPackPlugin extends Plugin {
         })
 
         // Prepare mutations
-        const mutations = engine.prepareMutations(findings)
+        const mutations = engine.prepareMutations(findings, rules)
 
         // Save connections
         processConnectionsBetweenEntities({

--- a/src/plugins/policyPack/index.ts
+++ b/src/plugins/policyPack/index.ts
@@ -186,19 +186,18 @@ export default class PolicyPackPlugin extends Plugin {
   }
 
   // TODO: Generalize data processor moving storage module to SDK with its interfaces
-  private getDataProcessor({
-    entity,
-    provider,
-  }: {
-    entity: string
-    provider: string
+  private getDataProcessor(config: {
+    providerName: string
+    entityName: string
+    typenameToFieldMap?: { [tn: string]: string }
+    extraFields?: string[]
   }): DataProcessor {
-    const dataProcessorKey = `${provider}${entity}`
+    const dataProcessorKey = `${config.providerName}${config.entityName}`
     if (this.dataProcessors[dataProcessorKey]) {
       return this.dataProcessors[dataProcessorKey]
     }
 
-    const dataProcessor = new DgraphDataProcessor(provider, entity)
+    const dataProcessor = new DgraphDataProcessor(config)
     this.dataProcessors[dataProcessorKey] = dataProcessor
     return dataProcessor
   }
@@ -256,13 +255,16 @@ export default class PolicyPackPlugin extends Plugin {
         continue // eslint-disable-line no-continue
       }
 
-      // Initialize RulesEngine
-      const rulesEngine = new RulesEngine({
+      // Initialize Data Processor
+      const dataProcessor = this.getDataProcessor({
         providerName: this.provider.name,
         entityName: policyPackPlugin.entity,
         typenameToFieldMap: resourceTypeNamesToFieldsMap,
         extraFields: policyPackPlugin.extraFields,
       })
+
+      // Initialize RulesEngine
+      const rulesEngine = new RulesEngine(dataProcessor)
 
       this.policyPacksPlugins[policyPack] = {
         engine: rulesEngine,
@@ -318,14 +320,8 @@ export default class PolicyPackPlugin extends Plugin {
           storageEngine,
         })
 
-        // Data Processor
-        const dataProcessor = this.getDataProcessor({
-          entity,
-          provider: this.provider.name,
-        })
-
         // Prepare mutations
-        const mutations = dataProcessor.prepareMutations(findings)
+        const mutations = engine.prepareMutations(findings)
 
         // Save connections
         processConnectionsBetweenEntities({

--- a/src/rules-engine/data-processors/data-processor.ts
+++ b/src/rules-engine/data-processors/data-processor.ts
@@ -1,5 +1,5 @@
 import { Entity } from '../../types'
-import { RuleFinding } from '../types'
+import { Rule, RuleFinding } from '../types'
 
 export default interface DataProcessor {
   readonly typenameToFieldMap: { [typeName: string]: string }
@@ -17,5 +17,12 @@ export default interface DataProcessor {
    * @param findings resulted findings during rules execution
    * @returns {Entity[]} Array of generated mutations
    */
-  prepareMutations: (findings: RuleFinding[]) => Entity[]
+  prepareFindingsMutations: (findings: RuleFinding[]) => Entity[]
+
+  /**
+   * Transforms Rules array into a mutation array for GraphQL
+   * @param rules rules metadata
+   * @returns {Entity[]} Array of generated mutations
+   */
+  prepareRulesMetadataMutations: (rules: Rule[]) => Entity[]
 }

--- a/src/rules-engine/data-processors/data-processor.ts
+++ b/src/rules-engine/data-processors/data-processor.ts
@@ -2,6 +2,16 @@ import { Entity } from '../../types'
 import { RuleFinding } from '../types'
 
 export default interface DataProcessor {
+  readonly typenameToFieldMap: { [typeName: string]: string }
+
+  readonly extraFields: string[]
+
+  /**
+   * Returns an GraphQL schema build dynamically based on the provider and existing resources
+   * @returns new schemas and extensions for existing ones
+   */
+  getSchema: () => string[]
+
   /**
    * Transforms RuleFinding array into a mutation array for GraphQL
    * @param findings resulted findings during rules execution

--- a/src/rules-engine/data-processors/dgraph-data-processor.ts
+++ b/src/rules-engine/data-processors/dgraph-data-processor.ts
@@ -168,10 +168,22 @@ export default class DgraphDataProcessor implements DataProcessor {
                 key => this.typenameToFieldMap[key] === finding.typename
               )
 
+              // Set required fields to allow resource insertion
+              const requiredFields = !isEmpty(this.extraFields)
+                ? this.extraFields.reduce(
+                    (acc, current) => ({
+                      ...acc,
+                      [current]: finding[current],
+                    }),
+                    {}
+                  )
+                : {}
+
               return {
                 ...finding,
                 [resourceType]: {
                   id: resource,
+                  ...requiredFields,
                 },
               }
             })

--- a/src/rules-engine/evaluators/js-evaluator.ts
+++ b/src/rules-engine/evaluators/js-evaluator.ts
@@ -14,20 +14,20 @@ export default class JsEvaluator implements RuleEvaluator<JsRule> {
   }
 
   async evaluateSingleResource(
-    rule: JsRule,
+    { id, check, severity }: JsRule,
     data: ResourceData
   ): Promise<RuleFinding> {
-    const { gql, check, resource, ...ruleMetadata } = rule
-    const result = rule.check!(data)
-      ? RuleResult.MATCHES
-      : RuleResult.DOESNT_MATCH
+    const result = check!(data) ? RuleResult.MATCHES : RuleResult.DOESNT_MATCH
 
     const finding = {
-      id: `${rule.id}/${data.resource?.id}`,
+      id: `${id}/${data.resource?.id}`,
       resourceId: data.resource?.id,
       result: result !== RuleResult.MATCHES ? Result.FAIL : Result.PASS,
       typename: data.resource?.__typename, // eslint-disable-line no-underscore-dangle
-      rule: ruleMetadata,
+      rule: {
+        id,
+        severity,
+      },
     } as RuleFinding
     return finding
   }

--- a/src/rules-engine/evaluators/json-evaluator.ts
+++ b/src/rules-engine/evaluators/json-evaluator.ts
@@ -20,20 +20,22 @@ export default class JsonEvaluator implements RuleEvaluator<JsonRule> {
   }
 
   async evaluateSingleResource(
-    rule: JsonRule,
+    { id, conditions, severity }: JsonRule,
     data: ResourceData
   ): Promise<RuleFinding> {
-    const { gql, conditions, resource, ...ruleMetadata } = rule
-    const result = (await this.evaluateCondition(rule.conditions, data))
+    const result = (await this.evaluateCondition(conditions, data))
       ? RuleResult.MATCHES
       : RuleResult.DOESNT_MATCH
 
     const finding = {
-      id: `${rule.id}/${data.resource?.id}`,
+      id: `${id}/${data.resource?.id}`,
       resourceId: data.resource?.id,
       result: result !== RuleResult.MATCHES ? Result.FAIL : Result.PASS,
       typename: data.resource?.__typename, // eslint-disable-line no-underscore-dangle
-      rule: ruleMetadata,
+      rule: {
+        id,
+        severity,
+      },
     } as RuleFinding
     return finding
   }

--- a/src/rules-engine/evaluators/manual-evaluator.ts
+++ b/src/rules-engine/evaluators/manual-evaluator.ts
@@ -6,12 +6,15 @@ export default class ManualEvaluator implements RuleEvaluator<JsonRule> {
     return !('gql' in rule) && !('conditions' in rule) && !('resource' in rule)
   }
 
-  async evaluateSingleResource(rule: Rule): Promise<RuleFinding> {
+  async evaluateSingleResource({ id, severity }: Rule): Promise<RuleFinding> {
     return {
-      id: `${rule.id}/manual`,
+      id: `${id}/manual`,
       result: Result.SKIPPED,
       typename: 'manual',
-      rule,
+      rule: {
+        id,
+        severity,
+      },
     } as RuleFinding
   }
 }

--- a/src/rules-engine/index.ts
+++ b/src/rules-engine/index.ts
@@ -6,33 +6,16 @@ import ManualEvaluator from './evaluators/manual-evaluator'
 import JsEvaluator from './evaluators/js-evaluator'
 import { RuleEvaluator } from './evaluators/rule-evaluator'
 import { Engine, ResourceData, Rule, RuleFinding } from './types'
+import DataProcessor from './data-processors/data-processor'
+import { Entity } from '../types'
 
 export default class RulesProvider implements Engine {
   evaluators: RuleEvaluator<any>[] = []
 
-  private readonly typenameToFieldMap: { [typeName: string]: string }
+  private readonly dataProcessor: DataProcessor
 
-  private readonly extraFields: string[]
-
-  private readonly providerName
-
-  private readonly entityName
-
-  constructor({
-    providerName,
-    entityName,
-    typenameToFieldMap,
-    extraFields,
-  }: {
-    providerName: string
-    entityName: string
-    typenameToFieldMap?: { [tn: string]: string }
-    extraFields?: string[]
-  }) {
-    this.extraFields = extraFields ?? []
-    this.typenameToFieldMap = typenameToFieldMap ?? {}
-    this.entityName = entityName
-    this.providerName = providerName
+  constructor(dataProcessor: DataProcessor) {
+    this.dataProcessor = dataProcessor
     this.evaluators = [
       new JsonEvaluator(),
       new JsEvaluator(),
@@ -69,13 +52,13 @@ export default class RulesProvider implements Engine {
     const finding = await evaluator.evaluateSingleResource(rule, data)
 
     // Inject extra fields
-    for (const field of this.extraFields) {
+    for (const field of this.dataProcessor.extraFields) {
       finding[field] = data.resource[field]
     }
 
     const connField =
       data.resource.__typename && // eslint-disable-line no-underscore-dangle
-      this.typenameToFieldMap[data.resource.__typename] // eslint-disable-line no-underscore-dangle
+      this.dataProcessor.typenameToFieldMap[data.resource.__typename] // eslint-disable-line no-underscore-dangle
 
     if (connField) {
       finding[connField] = [{ id: data.resource.id }]
@@ -100,71 +83,7 @@ export default class RulesProvider implements Engine {
     return data
   }
 
-  getSchema = (): string[] => {
-    const mainType = `
-    enum FindingsResult {
-      PASS
-      FAIL
-      MISSING
-      SKIPPED
-    }
-
-    type ${this.providerName}Findings @key(fields: "id") {
-      id: String! @id
-      ${this.entityName}Findings: [${this.providerName}${
-      this.entityName
-    }Findings]
-    }
-
-    type ruleMetadata @key(fields: "id") {
-      id: String! @id @search(by: [hash, regexp])
-      severity: String! @search(by: [hash, regexp])
-      description: String! @search(by: [hash, regexp])
-      title: String @search(by: [hash, regexp])
-      audit: String @search(by: [hash, regexp])
-      rationale: String @search(by: [hash, regexp])
-      remediation: String @search(by: [hash, regexp])
-      references: [String] @search(by: [hash, regexp])
-      findings: [baseFinding] @hasInverse(field: rule)
-    }
-
-    interface baseFinding {
-      id: String! @id
-      resourceId: String @search(by: [hash, regexp])
-      rule: [ruleMetadata] @hasInverse(field: findings)
-      result: FindingsResult @search
-    }
-
-    type ${this.providerName}${
-      this.entityName
-    }Findings implements baseFinding @key(fields: "id") {
-      findings: ${this.providerName}Findings  @hasInverse(field: ${
-      this.entityName
-    }Findings)
-      # extra fields
-      ${this.extraFields.map(
-        field => `${field}: String @search(by: [hash, regexp])`
-      )}
-      # connections
-       ${Object.keys(this.typenameToFieldMap)
-         .map(
-           (tn: string) =>
-             `${tn}: [${this.typenameToFieldMap[tn]}] @hasInverse(field: ${this.entityName}Findings)`
-         )
-         .join(' ')}
-    }
-      `
-    const extensions = Object.keys(this.typenameToFieldMap)
-      .map(
-        (tn: string) =>
-          `extend type ${this.typenameToFieldMap[tn]} {
-   ${this.entityName}Findings: [${this.providerName}${this.entityName}Findings] @hasInverse(field: ${tn})
-}`
-      )
-      .join('\n')
-
-    return [mainType, extensions]
-  }
+  getSchema = (): string[] => this.dataProcessor.getSchema()
 
   processRule = async (rule: Rule, data: unknown): Promise<RuleFinding[]> => {
     const res: any[] = []
@@ -215,4 +134,7 @@ export default class RulesProvider implements Engine {
     }
     return res
   }
+
+  prepareMutations = (findings: RuleFinding[]): Entity[] =>
+    this.dataProcessor.prepareMutations(findings)
 }

--- a/src/rules-engine/index.ts
+++ b/src/rules-engine/index.ts
@@ -135,6 +135,8 @@ export default class RulesProvider implements Engine {
     return res
   }
 
-  prepareMutations = (findings: RuleFinding[]): Entity[] =>
-    this.dataProcessor.prepareMutations(findings)
+  prepareMutations = (findings: RuleFinding[], rules: Rule[]): Entity[] => [
+    ...this.dataProcessor.prepareRulesMetadataMutations(rules),
+    ...this.dataProcessor.prepareFindingsMutations(findings),
+  ]
 }

--- a/src/rules-engine/types.ts
+++ b/src/rules-engine/types.ts
@@ -1,3 +1,5 @@
+import { Entity } from '../types'
+
 export type ResourceData = {
   data: { [k: string]: any }
   resource: { id: string; [k: string]: any }
@@ -83,4 +85,11 @@ export interface Engine {
    * @returns An array of RuleFinding
    */
   processRule: (rule: Rule, data: any) => Promise<RuleFinding[]>
+
+  /**
+   * Transforms RuleFinding array into a mutation array for GraphQL
+   * @param findings resulted findings during rules execution
+   * @returns {Entity[]} Array of generated mutations
+   */
+  prepareMutations: (findings: RuleFinding[]) => Entity[]
 }

--- a/src/rules-engine/types.ts
+++ b/src/rules-engine/types.ts
@@ -89,7 +89,8 @@ export interface Engine {
   /**
    * Transforms RuleFinding array into a mutation array for GraphQL
    * @param findings resulted findings during rules execution
+   * @param rules rules metadata
    * @returns {Entity[]} Array of generated mutations
    */
-  prepareMutations: (findings: RuleFinding[]) => Entity[]
+  prepareMutations: (findings: RuleFinding[], rules: Rule[]) => Entity[]
 }

--- a/tests/rules-engine.test.ts
+++ b/tests/rules-engine.test.ts
@@ -1,11 +1,8 @@
-import cuid from 'cuid'
-
 import RulesProvider from '../src/rules-engine'
 import { Engine, Rule } from '../src/rules-engine/types'
 import ManualEvaluatorMock from './evaluators/manual-evaluator.test'
 import JSONEvaluatordMock from './evaluators/json-evaluator.test'
 import DgraphDataProcessor from '../src/rules-engine/data-processors/dgraph-data-processor'
-import DataProcessor from '../src/rules-engine/data-processors/data-processor'
 
 const typenameToFieldMap = {
   resourceA: 'querySchemaA',
@@ -16,14 +13,13 @@ const entityName = 'CIS'
 
 describe('RulesEngine', () => {
   let rulesEngine: Engine
-  let dataProcessor: DataProcessor
   beforeEach(() => {
-    rulesEngine = new RulesProvider({
+    const dataProcessor = new DgraphDataProcessor({
       providerName,
       entityName,
       typenameToFieldMap,
     })
-    dataProcessor = new DgraphDataProcessor(providerName, entityName)
+    rulesEngine = new RulesProvider(dataProcessor)
   })
   it('Should pass getting the updated schema created dynamically using schemaTypeName and typenameToFieldMap fields', () => {
     const schema = rulesEngine.getSchema()
@@ -42,7 +38,7 @@ describe('RulesEngine', () => {
       ManualEvaluatorMock.manualRule as Rule,
       undefined
     )
-    const [mutations] = dataProcessor.prepareMutations(findings)
+    const [mutations] = rulesEngine.prepareMutations(findings)
 
     expect(findings.length).toBe(1)
     expect(mutations).toBeDefined()
@@ -52,40 +48,6 @@ describe('RulesEngine', () => {
     expect(mutations.mutation).toContain(
       `add${providerName}${entityName}Findings`
     )
-  })
-
-  it('Should pass preparing the mutations to insert findings data given a RuleFindings array with Automated Rules', async () => {
-    const resourceId = cuid()
-    const resourceType = 'schemaA'
-    const findings = await rulesEngine.processRule(
-      JSONEvaluatordMock.jsonRule as Rule,
-      {
-        querySchemaA: [
-          {
-            id: resourceId,
-            __typename: resourceType,
-            value: 'automated',
-          },
-        ],
-      }
-    )
-    const [mutations] = dataProcessor.prepareMutations(findings)
-
-    expect(findings.length).toBe(1)
-    expect(mutations).toBeDefined()
-    expect(mutations.data instanceof Object).toBeTruthy()
-    expect(mutations.data.filter.id.eq).toBe(resourceId)
-    expect(mutations.name).toBe(`${providerName}${entityName}Findings`)
-    expect(mutations.mutation).toContain(`update${resourceType}`)
-  })
-
-  it('Should pass preparing the mutations to insert with an empty findings array', () => {
-    const data = []
-
-    const entities = dataProcessor.prepareMutations(data)
-
-    expect(entities).toBeDefined()
-    expect(entities.length).toBe(2)
   })
 
   it('Should return an empty array processing a rule with no data', async () => {
@@ -99,5 +61,14 @@ describe('RulesEngine', () => {
     expect(processedRule).toBeDefined()
     expect(processedRule instanceof Array).toBeTruthy()
     expect(processedRule.length).toBe(0)
+  })
+
+  it('Should return empty mutations array given an empty findings array', () => {
+    const data = []
+
+    const entities = rulesEngine.prepareMutations(data)
+
+    expect(entities).toBeDefined()
+    expect(entities.length).toBe(0)
   })
 })

--- a/tests/rules-engine.test.ts
+++ b/tests/rules-engine.test.ts
@@ -38,7 +38,7 @@ describe('RulesEngine', () => {
       ManualEvaluatorMock.manualRule as Rule,
       undefined
     )
-    const [mutations] = rulesEngine.prepareMutations(findings)
+    const [mutations] = rulesEngine.prepareMutations(findings, [])
 
     expect(findings.length).toBe(1)
     expect(mutations).toBeDefined()
@@ -66,7 +66,7 @@ describe('RulesEngine', () => {
   it('Should return empty mutations array given an empty findings array', () => {
     const data = []
 
-    const entities = rulesEngine.prepareMutations(data)
+    const entities = rulesEngine.prepareMutations(data, [])
 
     expect(entities).toBeDefined()
     expect(entities.length).toBe(0)


### PR DESCRIPTION
Performance increased drastically, reducing the number of mutations. from 362 mutations in 10.379s  to 4 mutations in 3.381s

Also, the redundant data in the mutations data was optimized to decrease the payload size.

Depends on https://github.com/cloudgraphdev/cloudgraph-provider-aws/pull/4
Depends on https://github.com/cloudgraphdev/cloudgraph-policy-packs/pull/1