### PR TITLE
feat: Extend rule engine to include missing checks when the resource …

### DIFF
--- a/src/rules-engine/data-processors/dgraph-data-processor.ts
+++ b/src/rules-engine/data-processors/dgraph-data-processor.ts
@@ -145,12 +145,12 @@ export default class DgraphDataProcessor implements DataProcessor {
 
   private prepareEntitiesMutations(findings: RuleFinding[]): RuleFinding[] {
     // Group Findings by schema type
-    const { manual: manualData = [], ...processedRules } = groupBy(
+    const { manual: manualData = [], missing: missingData = [], ...processedRules } = groupBy(
       findings,
       'typename'
     )
 
-    const mutations = [...manualData]
+    const mutations = [...manualData, ...missingData]
     for (const findingType in processedRules) {
       if (!isEmpty(findingType)) {
         // Group Findings by resource

--- a/src/rules-engine/evaluators/base-evaluator.ts
+++ b/src/rules-engine/evaluators/base-evaluator.ts
@@ -8,7 +8,7 @@ export default abstract class BaseEvaluator<K extends Rule> implements RuleEvalu
 
   abstract evaluateSingleResource(rule: K, data?: ResourceData): Promise<RuleFinding>
 
-  async evaluateMissingResource({ id, severity, resource }: K): Promise<RuleFinding> {
+  async evaluateMissingResource({ id, severity, resource }: Rule): Promise<RuleFinding> {
     return {
       id: `${id}/missing/${cuid()}`,
       resourceId: resource?.replace('[*]', ''),

--- a/src/rules-engine/evaluators/base-evaluator.ts
+++ b/src/rules-engine/evaluators/base-evaluator.ts
@@ -1,0 +1,23 @@
+import cuid from 'cuid'
+import { ResourceData, Result, Rule, RuleFinding } from '../types'
+import { RuleEvaluator } from './rule-evaluator'
+
+export default abstract class BaseEvaluator<K extends Rule> implements RuleEvaluator<K>
+{
+  abstract canEvaluate(rule: K): boolean
+
+  abstract evaluateSingleResource(rule: K, data?: ResourceData): Promise<RuleFinding>
+
+  async evaluateMissingResource({ id, severity, resource }: K): Promise<RuleFinding> {
+    return {
+      id: `${id}/missing/${cuid()}`,
+      resourceId: resource?.replace('[*]', ''),
+      result: Result.MISSING,
+      typename: 'missing',
+      rule: {
+        id,
+        severity,
+      },
+    } as RuleFinding
+  }
+}

--- a/src/rules-engine/evaluators/js-evaluator.ts
+++ b/src/rules-engine/evaluators/js-evaluator.ts
@@ -6,9 +6,9 @@ import {
   RuleFinding,
   Result,
 } from '../types'
-import { RuleEvaluator } from './rule-evaluator'
+import BaseEvaluator from './base-evaluator'
 
-export default class JsEvaluator implements RuleEvaluator<JsRule> {
+export default class JsEvaluator extends BaseEvaluator<JsRule> {
   canEvaluate(rule: Rule | JsRule): boolean {
     return 'check' in rule
   }

--- a/src/rules-engine/evaluators/json-evaluator.ts
+++ b/src/rules-engine/evaluators/json-evaluator.ts
@@ -12,9 +12,9 @@ import {
 } from '../types'
 import AdditionalOperators from '../operators'
 import ComparisonOperators from '../operators/comparison'
-import { RuleEvaluator } from './rule-evaluator'
+import BaseEvaluator from './base-evaluator'
 
-export default class JsonEvaluator implements RuleEvaluator<JsonRule> {
+export default class JsonEvaluator extends BaseEvaluator<JsonRule> {
   canEvaluate(rule: JsonRule): boolean {
     return 'conditions' in rule
   }

--- a/src/rules-engine/evaluators/manual-evaluator.ts
+++ b/src/rules-engine/evaluators/manual-evaluator.ts
@@ -1,7 +1,7 @@
 import { JsonRule, Result, Rule, RuleFinding } from '../types'
-import { RuleEvaluator } from './rule-evaluator'
+import BaseEvaluator from './base-evaluator'
 
-export default class ManualEvaluator implements RuleEvaluator<JsonRule> {
+export default class ManualEvaluator extends BaseEvaluator<JsonRule> {
   canEvaluate(rule: Rule): boolean {
     return !('gql' in rule) && !('conditions' in rule) && !('resource' in rule)
   }

--- a/src/rules-engine/evaluators/rule-evaluator.ts
+++ b/src/rules-engine/evaluators/rule-evaluator.ts
@@ -3,4 +3,5 @@ import { ResourceData, Rule, RuleFinding } from '../types'
 export interface RuleEvaluator<K extends Rule> {
   canEvaluate: (rule: K) => boolean
   evaluateSingleResource: (rule: K, data?: ResourceData) => Promise<RuleFinding>
+  evaluateMissingResource: (rule: K) => Promise<RuleFinding>
 }

--- a/src/rules-engine/index.ts
+++ b/src/rules-engine/index.ts
@@ -91,14 +91,20 @@ export default class RulesProvider implements Engine {
     const resourcePaths = data ? jsonpath.nodes(data, rule.resource) : []
     const evaluator = this.getRuleEvaluator(rule)
 
+    if (!evaluator) {
+      return []
+    }
+
     if (isEmpty(data) && evaluator instanceof ManualEvaluator) {
       // Returned Manual Rule Response
       res.push(await evaluator.evaluateSingleResource(rule))
       return res
     }
 
-    if (!evaluator) {
-      return []
+    if (isEmpty(resourcePaths)) {
+      // Returned Missing Resource Rule Response   
+      res.push(await evaluator.evaluateMissingResource(rule))
+      return res
     }
 
     // @NOTE: here we can evaluate things such as Data being empty (may imply rule to pass)

--- a/tests/evaluators/js-evaluator.test.ts
+++ b/tests/evaluators/js-evaluator.test.ts
@@ -66,4 +66,25 @@ describe('JsEvaluator', () => {
     )
     expect(passedRule.result).toEqual(Result.PASS)
   })
+
+  test('should return missing as result', async () => {
+    const finding = await evaluator.evaluateMissingResource(
+      { id: cuid() } as never
+    )
+    expect(finding.result).toEqual(Result.MISSING)
+  })
+
+  test('should contain "missing" at the id', async () => {
+    const finding = await evaluator.evaluateMissingResource(
+      { id: cuid() } as any
+    )
+    expect(finding.id.includes('missing')).toEqual(true)
+  })
+
+  test('should return the resource path at the resourceId', async () => {
+    const finding = await evaluator.evaluateMissingResource(
+      { id: cuid(), resource: 'resourcePath[*]'} as any
+    )
+    expect(finding.resourceId).toEqual('resourcePath')
+  })
 })

--- a/tests/evaluators/json-evaluator.test.ts
+++ b/tests/evaluators/json-evaluator.test.ts
@@ -596,4 +596,25 @@ describe('JsonEvaluator', () => {
 
     expect(finding.result).toBe(Result.FAIL)
   })
+
+  test('should return missing as result', async () => {
+    const finding = await evaluator.evaluateMissingResource(
+      { id: cuid() } as never
+    )
+    expect(finding.result).toEqual(Result.MISSING)
+  })
+
+  test('should contain "missing" at the id', async () => {
+    const finding = await evaluator.evaluateMissingResource(
+      { id: cuid() } as any
+    )
+    expect(finding.id.includes('missing')).toEqual(true)
+  })
+
+  test('should return the resource path at the resourceId', async () => {
+    const finding = await evaluator.evaluateMissingResource(
+      { id: cuid(), resource: 'resourcePath[*]'} as any
+    )
+    expect(finding.resourceId).toEqual('resourcePath')
+  })
 })

--- a/tests/rules-engine.test.ts
+++ b/tests/rules-engine.test.ts
@@ -1,8 +1,9 @@
 import RulesProvider from '../src/rules-engine'
-import { Engine, Rule } from '../src/rules-engine/types'
+import { Engine, Result, Rule } from '../src/rules-engine/types'
 import ManualEvaluatorMock from './evaluators/manual-evaluator.test'
 import JSONEvaluatordMock from './evaluators/json-evaluator.test'
 import DgraphDataProcessor from '../src/rules-engine/data-processors/dgraph-data-processor'
+import { RuleFinding } from '../src'
 
 const typenameToFieldMap = {
   resourceA: 'querySchemaA',
@@ -50,17 +51,17 @@ describe('RulesEngine', () => {
     )
   })
 
-  it('Should return an empty array processing a rule with no data', async () => {
+  it('Should return a missing finding type processing a rule with no data', async () => {
     const data = {}
 
     const processedRule = await rulesEngine.processRule(
       JSONEvaluatordMock.jsonRule,
       data
-    )
+    ) as RuleFinding[]
 
     expect(processedRule).toBeDefined()
-    expect(processedRule instanceof Array).toBeTruthy()
-    expect(processedRule.length).toBe(0)
+    expect(processedRule.length).toBe(1)
+    expect(processedRule[0].result).toBe(Result.MISSING)
   })
 
   it('Should return empty mutations array given an empty findings array', () => {


### PR DESCRIPTION
…does not exist

## Issue tracker links

_Add links to any relevant tasks/stories/bugs/pagerduty/etc_

*Example - dummy TODO project*

[TODO-123](https://autoclouddev.atlassian.net/browse/TODO-123)

## Changes/solution

New 'MISSING' finding type was added for the rules that are not executed either because the resource does not exist or it was not included in the scan:

```
  {
    "id": "gcp-cis-1.2.0-2.4/missing/cl477y3eq0000ehngds9x3gvk",
    "resourceId": "querygcpAlertPolicy",
    "result": "MISSING",
    "typename": "missing",
    "rule": {
      "id": "gcp-cis-1.2.0-2.4",
      "severity": "high"
    }
  }
```
- This Id is unique, it will not be repeated through the projects
- It has the following formar: `${id}/missing/${cuid()}`, the cuid() was added for cases where the same rule is evaluated more than once, i.e. for rules that have multiple queries, e.g. 3.9:

```
  {
    "id": "gcp-cis-1.2.0-3.9/missing/cl477y3ey0001ehnga5076ya5",
    "resourceId": "querygcpTargetHttpsProxy",
    "result": "MISSING",
    "typename": "missing",
    "rule": {
      "id": "gcp-cis-1.2.0-3.9",
      "severity": "medium"
    }
  },
  {
    "id": "gcp-cis-1.2.0-3.9/missing/cl477y3f20002ehng65l9c82m",
    "resourceId": "querygcpTargetSslProxy",
    "result": "MISSING",
    "typename": "missing",
    "rule": {
      "id": "gcp-cis-1.2.0-3.9",
      "severity": "medium"
    }
  }
```

- The resourceId was set with the attached resource in the metadata of the rule.

- This solution also contemplate the case reported in this [Spike](https://autoclouddev.atlassian.net/browse/CG-997), in which the rule is not evaluated because the resource is not included in the scan.

## Testing

_Describe how the testing was done, plus evidence, if not covered by automated tests_

## Notes and considerations

_Add any additional notes and/or considerations_

## Dependencies

_Add dependencies on any other PRs, if applicable 
